### PR TITLE
Add better support for sparse registries

### DIFF
--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -180,7 +180,7 @@ module Dependabot
           {
             type: "registry+sparse",
             name: registry_name,
-            index: index_url[7..-2], # Chop off the final /.
+            index: index_url.delete_prefix("sparse+").delete_suffix("/"),
             dl: nil,
             api: nil
           }

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -171,30 +171,18 @@ module Dependabot
                 "cargo config"
         end
 
-        # Handling sparse registries in common::lib::Dependabot::Source is not 
-        # impossible, but there are only two such "sparse-only" registries which we 
-        # care about ("sparse-only" meaning doesn't support querying via the 
-        # "non-standard API" https://#{registry.dl}/#{crate} on which we otherwise 
-        # rely). Both of those registries would also require logic for client
-        # authentication if we do this in Source, so we use known values here to avoid
-        # this, but record that these are sparse so we can query crates in a way that
-        # they support.
-        if index_url == "sparse+https://crates.microsoft.com/index/"
+        # "Handling" sparse registries in common::lib::Dependabot::Source is not 
+        # impossible (i.e., by getting the config.json file from the index endpoint) 
+        # but sparse registries have their indices at the supplied URI minus the 
+        # `sparse+` header, and we only need to call on the index URI - so just 
+        # supply that information here instead.
+        if index_url.start_with? "sparse+"
           {
             type: "registry+sparse",
             name: registry_name,
-            index: index_url,
-            dl: "https://crates.microsoft.com/api/v1/crates",
-            api: "https://crates.microsoft.com"
-          }
-
-        elsif index_url == "sparse+https://pkgs.dev.azure.com/msazuredev/AzureForOperators/_packaging/rust/Cargo/index/"
-          {
-            type: "registry+sparse",
-            name: registry_name,
-            index: index_url,
-            dl: nil, # We can only query version info using the sparse API for this registry.
-            api: "https://pkgs.dev.azure.com/msazuredev/AzureForOperators/_packaging/rust/Cargo/index"
+            index: index_url[7..-2], # Chop off the final /.
+            dl: nil,
+            api: nil
           }
           
         else

--- a/cargo/lib/dependabot/cargo/registry_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/registry_fetcher.rb
@@ -34,13 +34,7 @@ module Dependabot
       end
 
       def config_json
-        # Treat crates.microsoft.com as a special case and return known values
-        # rather than querying config.json to avoid having to deal with authentication.
-        if source == "sparse+https://crates.microsoft.com/index/config.json"
-          @config_json = '{"dl":"https://crates.microsoft.com/api/v1/crates","api":"https://crates.microsoft.com","always-auth":true}'
-        else
-          @config_json ||= fetch_file_from_host("config.json")
-        end
+        @config_json ||= fetch_file_from_host("config.json")
       end
     end
   end

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -69,7 +69,8 @@ module Dependabot
         end
 
         def available_versions
-          # Sparse registries return listings in different formats.
+          # Sparse registries return listings in a different format to the "default"
+          # undocumented API on which we rely when our source isn't sparse.
           if is_sparse
             crates_listing.
               reject { |v| v["yanked"] }.
@@ -127,7 +128,9 @@ module Dependabot
           # Default request headers
           hdrs = { "User-Agent" => "Dependabot (dependabot.com)" }
 
-          registry_token_var_name = "CARGO_REGISTRIES_#{registry_name.upcase}_TOKEN"
+          # See https://doc.rust-lang.org/cargo/reference/environment-variables.html
+          # for details on how this variable name is decided.
+          registry_token_var_name = "CARGO_REGISTRIES_#{registry_name.upcase.gsub '/[^0-9a-z]/i', '_'}_TOKEN"
           raise "Must specify #{registry_token_var_name}" if ENV[registry_token_var_name].nil?
           hdrs["Authorization"] = ENV[registry_token_var_name]
           

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -69,26 +69,43 @@ module Dependabot
         end
 
         def available_versions
-          crates_listing.
-            fetch("versions", []).
-            reject { |v| v["yanked"] }.
-            map { |v| version_class.new(v.fetch("num")) }
+          # Sparse registries return listings in different formats.
+          if is_sparse
+            crates_listing.
+              reject { |v| v["yanked"] }.
+              map { |v| version_class.new(v.fetch("vers")) }
+          else
+            crates_listing.
+              fetch("versions", []).
+              reject { |v| v["yanked"] }.
+              map { |v| version_class.new(v.fetch("num")) }
+          end
+        end
+
+        def is_sparse
+          return @is_sparse unless @is_sparse.nil?
+          info = dependency.requirements.map { |r| r[:source] }.compact.first
+          @is_sparse = info && info[:type] == "registry+sparse"
         end
 
         def crates_listing
           return @crates_listing unless @crates_listing.nil?
+          @crates_listing = is_sparse ? crates_listing_sparse : crates_listing_non_sparse
+        rescue Excon::Error::Timeout
+          retrying ||= false
+          raise if retrying
 
+          retrying = true
+          sleep(rand(1.0..5.0)) && retry
+        end
+        
+        def crates_listing_non_sparse
           info = dependency.requirements.map { |r| r[:source] }.compact.first
           dl = info && info[:dl] || CRATES_IO_DL
 
           # Default request headers
           hdrs = { "User-Agent" => "Dependabot (dependabot.com)" }
 
-          # crates.microsoft.com requires an auth token
-          if dl == "https://crates.microsoft.com/api/v1/crates"
-            raise "Must specify CARGO_REGISTRIES_CRATES_MS_TOKEN" if ENV["CARGO_REGISTRIES_CRATES_MS_TOKEN"].nil?
-            hdrs["Authorization"] = ENV["CARGO_REGISTRIES_CRATES_MS_TOKEN"]
-          end
 
           response = Excon.get(
             "#{dl}/#{dependency.name}",
@@ -97,13 +114,45 @@ module Dependabot
             **SharedHelpers.excon_defaults
           )
 
-          @crates_listing = JSON.parse(response.body)
-        rescue Excon::Error::Timeout
-          retrying ||= false
-          raise if retrying
+          JSON.parse(response.body)
+        end
 
-          retrying = true
-          sleep(rand(1.0..5.0)) && retry
+        def crates_listing_sparse
+          info = dependency.requirements.map { |r| r[:source] }.compact.first
+          api = info && info[:api] 
+          raise "Registry uses sparse protocol but no API URI found" if api.nil?
+
+          # Default request headers
+          hdrs = { "User-Agent" => "Dependabot (dependabot.com)" }
+
+          # crates.microsoft.com, pkgs.dev.azure.com require an auth token
+          if api.include? "crates.microsoft.com"
+            raise "Must specify CARGO_REGISTRIES_CRATES_MS_TOKEN" if ENV["CARGO_REGISTRIES_CRATES_MS_TOKEN"].nil?
+            hdrs["Authorization"] = ENV["CARGO_REGISTRIES_CRATES_MS_TOKEN"]
+          elsif api.include? "pkgs.dev.azure.com"
+            raise "Must specify CARGO_REGISTRIES_AFO_TOKEN" if ENV["CARGO_REGISTRIES_AFO_TOKEN"].nil?
+            hdrs["Authorization"] = ENV["CARGO_REGISTRIES_AFO_TOKEN"]
+          end
+          
+          name = dependency.name
+          prefix = case name.length
+          when 1..2
+            name.length
+          when 3
+            "3/#{name[0]}"
+          else
+            "#{name[0..1]}/#{name[2..3]}"
+          end
+        
+          response = Excon.get(
+            "#{api}/#{prefix}/#{dependency.name}",
+            headers: hdrs,
+            idempotent: true,
+            **SharedHelpers.excon_defaults
+          )
+          
+          response.body.split("\n").
+            map { |v| JSON.parse(v) }
         end
 
         def wants_prerelease?

--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -68,7 +68,7 @@ module Dependabot
         m = url_string.match(source_info[:regex])
         return source_info[:factory].call(m.named_captures) if m
       end
-      puts "Source.from_url failed to find source for: #{url_string}"
+      raise "Source.from_url failed to find source for: #{url_string}"
     end
 
     def initialize(provider:, repo:, directory: nil, branch: nil, commit: nil,


### PR DESCRIPTION
This PR adds support for the sparse APF package feeds.

It accomplishes this by inspecting the discovered `index_url` (which is determined by matching the supplied `registry` string in `Cargo.toml`, if any, to the registries defined in any `.cargo/config[.toml]` files in the downstream consuming project) and populating the source details object with `registry+sparse` and chopping `sparse+` off the supplied value. Later, Dependabot checks whether a source is `registry+sparse` to determine the right way to query the latest available version of a package. This is significantly cheaper than implementing real support for determining index location of sparse registries in `Source::from_url` / `RegistryFetcher` because we would then need to solve the problem of authenticating with these registries at index-finding time. Instead, we later guess at which authentication token we need for peeking at these registries, using the supplied registry name, and supply it when we query from them.

This PR has been tested by running a downstream consuming project locally using this version of the code against some real projects.