### PR TITLE
fix: don't bail when we can't find source info

### DIFF
--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -17,6 +17,7 @@ module Dependabot
         case new_source_type
         when "default" then find_source_from_crates_listing
         when "registry" then find_source_from_crates_listing
+        when "registry+sparse" then return # We can't find source information from sparse registries.
         when "git" then find_source_from_git_url
         else raise "Unexpected source type: #{new_source_type}"
         end

--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -68,7 +68,7 @@ module Dependabot
         m = url_string.match(source_info[:regex])
         return source_info[:factory].call(m.named_captures) if m
       end
-      raise "Source.from_url failed to find source for: #{url_string}"
+      puts "Source.from_url failed to find source for: #{url_string}"
     end
 
     def initialize(provider:, repo:, directory: nil, branch: nil, commit: nil,


### PR DESCRIPTION
This PR demotes a couple of source-finding failure cases to logs or silent failures, since we can (and should) continue when these occur.

Sparse registry format does not provide any way for us to get the dependency's metadata (including links for repository, homepage, or documentation), whereas the undocumented `#{api_url}/#{crate}` link does. However, this source is only used for providing a better MR/PR overview, and this `source` being `nil` should not cause the process to fail.

The change in `source.rb` is a reversion of a line change from #240 - I had thought that this would improve diagnosability of failures, but in line with the above thinking this is actually not a fatal failure case so shouldn't be raising an exception.